### PR TITLE
gotator installation typo

### DIFF
--- a/active-enumeration/permutation-alterations.md
+++ b/active-enumeration/permutation-alterations.md
@@ -30,7 +30,7 @@ Gotator is DNS wordlist generator tool. It is used to generate various combinati
 ### Installation:
 
 ```bash
-go install -v https://github.com/Josue87/gotator@latest
+go install -v github.com/Josue87/gotator@latest
 ```
 
 ### Running:


### PR DESCRIPTION
Hey
Thank for your amazing content, while reading just saw this small typo 

the argument must be a clean package path like this
`go install -v github.com/Josue87/gotator@latest`